### PR TITLE
Fix broken JS examples (#39)

### DIFF
--- a/examples/javascript/index.html
+++ b/examples/javascript/index.html
@@ -14,8 +14,7 @@
     <button id="remote-connector-example-button">Run Websocket Connection Example</button>
     <button id="device-enumeration-example-button">Run Device Enumeration (Embedded) Example</button>
     <button id="device-control-example-button">Run Device Control (Embedded) Example</button>
-    <script lang="javascript" src="https://cdn.jsdelivr.net/npm/buttplug-wasm@1.0.7/dist/web/buttplug.js"></script>
-    <!-- <script lang="javascript" src="https://determined-allen-19d1dd.netlify.app/buttplug.js"></script> -->
+    <script lang="javascript" src="https://cdn.jsdelivr.net/npm/buttplug@1.0.17/dist/web/buttplug.min.js"></script>
     <script lang="javascript" src="async-example.js"></script>
     <script lang="javascript" src="errors-example.js"></script>
     <script lang="javascript" src="embedded-connector-example.js"></script>


### PR DESCRIPTION
The incorrect package is being used for the buttplug library so this fixes that by swapping it out for the latest version.